### PR TITLE
Build natively on Apple Silicon

### DIFF
--- a/CocoaMSX.xcodeproj/project.pbxproj
+++ b/CocoaMSX.xcodeproj/project.pbxproj
@@ -2807,7 +2807,7 @@
 				INFOPLIST_FILE = "CocoaMSX-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-DOSX",
 					"-DDEBUG",
@@ -2842,7 +2842,7 @@
 				INFOPLIST_FILE = "CocoaMSX-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-DOSX",
 					"-DFINAL",
@@ -2872,8 +2872,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
-				"HEADER_SEARCH_PATHS[arch=*]" = SBJson.framework/Headers;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DOSX",
@@ -2887,6 +2886,7 @@
 					"-DNO_ASM",
 					"-DDEBUG",
 					"-DOSX",
+					"-Wno-c++11-narrowing",
 				);
 				SDKROOT = macosx;
 			};
@@ -2905,8 +2905,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
-				"HEADER_SEARCH_PATHS[arch=*]" = SBJson.framework/Headers;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-DOSX",
 					"-DFINAL",
@@ -2919,6 +2918,7 @@
 					"-DNO_ASM",
 					"-DFINAL",
 					"-DOSX",
+					"-Wno-c++11-narrowing",
 				);
 				SDKROOT = macosx;
 			};

--- a/Src/Common/MsxTypes.h
+++ b/Src/Common/MsxTypes.h
@@ -45,7 +45,7 @@ extern "C" {
 
 /* Define double type for different targets
  */
-#if defined(__x86_64__) || defined(__i386__) || defined _WIN32
+#if defined(__x86_64__) || defined(__i386__) || defined(__aarch64__) || defined(__arm64__) || defined _WIN32
 typedef double DoubleT;
 #else
 typedef float DoubleT;

--- a/Src/Unzip/zutil.h
+++ b/Src/Unzip/zutil.h
@@ -128,7 +128,11 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #    include <unix.h> /* for fdopen */
 #  else
 #    ifndef fdopen
-#      define fdopen(fd,mode) NULL /* No fdopen() */
+#      if defined(__APPLE__)
+#        include <stdio.h>
+#      else
+#        define fdopen(fd,mode) NULL /* No fdopen() */
+#      endif
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
## Summary
- Fix embedded zlib `fdopen` macro conflict with modern macOS SDK headers
- Use `double` precision (`DoubleT`) on arm64 instead of incorrectly falling back to `float`
- Raise minimum deployment target from 10.7 to 11.0 for current Xcode toolchains
- Add `-Wno-c++11-narrowing` for legacy sound-chip C++ initializer code
- Remove stale `SBJson.framework` header search path (code now uses `NSJSONSerialization`)

## Test plan
- [x] `xcodebuild -scheme CocoaMSX -configuration Release build` on Apple Silicon (arm64)
- [x] Built binary verified as `Mach-O 64-bit executable arm64`
- [ ] Manual smoke test: launch app, load ROM, verify audio/video